### PR TITLE
Fix validation with multiple labels

### DIFF
--- a/functions/label.js
+++ b/functions/label.js
@@ -77,7 +77,7 @@ export async function checkLabel(event, context, callback) {
   }
 
   // loop thru PR labels to see if we found one which should block the PR
-  const validation = body.pull_request.labels.some(({ name }) => {
+  const validation = body.pull_request.labels.every(({ name }) => {
     if (blockLabels.find(blockLabel => blockLabel === name)) {
       console.log('Fail: at least one blocked label found')
 

--- a/functions/label.js
+++ b/functions/label.js
@@ -76,7 +76,7 @@ export async function checkLabel(event, context, callback) {
     return callback(null, response)
   }
 
-  // loop thru PR labels to see if we found one which should block the PR
+  // loop through PR labels to see if we found one which should block the PR
   const validation = body.pull_request.labels.every(({ name }) => {
     if (blockLabels.find(blockLabel => blockLabel === name)) {
       console.log('Fail: at least one blocked label found')


### PR DESCRIPTION
When there are multiple labels, we only check for few of them instead of checking for all of them.

Using `Array.some` when one label got valid, the check was stopped.
Using `Array.every` it'll check all labels.