### PR TITLE
Remove duplicate deps for Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "serverless-github-check",
-  "version": "1.2.1",
   "main": "handler.js",
   "scripts": {
     "test": "jest",
@@ -13,7 +12,6 @@
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/preset-env": "^7.10.3",
     "babel-eslint": "^10.1.0",
-    "babel-jest": "^26.1.0",
     "babel-loader": "^8.1.0",
     "babel-plugin-source-map-support": "^2.1.2",
     "eslint": "^7.3.1",
@@ -24,7 +22,6 @@
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.0",
     "jest": "^26.1.0",
-    "jest-cli": "^26.0.0",
     "regenerator-runtime": "^0.13.5",
     "serverless-offline": "^6.4.0",
     "serverless-webpack": "^5.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4361,7 +4361,7 @@ jest-changed-files@^26.1.0:
     execa "^4.0.0"
     throat "^5.0.0"
 
-jest-cli@^26.0.0, jest-cli@^26.1.0:
+jest-cli@^26.1.0:
   version "26.1.0"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-26.1.0.tgz#eb9ec8a18cf3b6aa556d9deaa9e24be12b43ad87"
   integrity sha512-Imumvjgi3rU7stq6SJ1JUEMaV5aAgJYXIs0jPqdUnF47N/Tk83EXfmtvNKQ+SnFVI6t6mDOvfM3aA9Sg6kQPSw==


### PR DESCRIPTION
`babel-jest` is required by `jest-config` which is required by `jest-cli` which is required by `jest`.
Which means, adding only `jest` to `package.json` will include all of them.

To validate that, a `yarn install` removed nothing from `yarn.lock`.
And @dependabot will send 2 PRs less each time Jest is updated :v: