### PR TITLE
Change the way to load handlers

### DIFF
--- a/functions/fixup.js
+++ b/functions/fixup.js
@@ -1,7 +1,7 @@
 import { client } from 'octonode'
 import { updateStatus, validateWebhook } from './utils/github'
 
-export async function checkFixupCommits(event, context, callback) {
+export async function handler(event, context, callback) {
   let response
   const githubClient = client(process.env.GITHUB_TOKEN)
   const payload = {

--- a/functions/label.js
+++ b/functions/label.js
@@ -1,7 +1,7 @@
 import { client } from 'octonode'
 import { updateStatus, validateWebhook } from './utils/github'
 
-export async function checkLabel(event, context, callback) {
+export async function handler(event, context, callback) {
   let response
   const githubClient = client(process.env.GITHUB_TOKEN)
   const blockLabels = process.env.BLOCK_LABELS

--- a/functions/specification.js
+++ b/functions/specification.js
@@ -1,7 +1,7 @@
 import { client } from 'octonode'
 import { updateStatus, validateWebhook } from './utils/github'
 
-export async function checkSpecification(event, context, callback) {
+export async function handler(event, context, callback) {
   let response
   const githubClient = client(process.env.GITHUB_TOKEN)
 

--- a/handler.js
+++ b/handler.js
@@ -1,5 +1,0 @@
-import { checkSpecification } from './functions/specification'
-import { checkLabel } from './functions/label'
-import { checkFixupCommits } from './functions/fixup'
-
-export { checkSpecification, checkLabel, checkFixupCommits }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "handler.js",
   "scripts": {
     "test": "jest",
-    "lint": "eslint functions/ tests/ handler.js"
+    "lint": "eslint functions/ tests/"
   },
   "author": "20 Minutes <web-tech@20minutes.fr>",
   "license": "MIT",

--- a/serverless.yml
+++ b/serverless.yml
@@ -25,7 +25,7 @@ custom:
 
 functions:
     specification:
-        handler: handler.checkSpecification
+        handler: functions/specification.handler
         description: Validate GitHub PRs against some specifications
         environment:
             CHECK_BODY_LENGTH: 8
@@ -44,7 +44,7 @@ functions:
                     cors: true
 
     label:
-        handler: handler.checkLabel
+        handler: functions/label.handler
         description: Check for GitHub PR labels to block merge
         environment:
             # coma separated labels
@@ -57,7 +57,7 @@ functions:
                     cors: true
 
     fixup:
-        handler: handler.checkFixupCommits
+        handler: functions/fixup.handler
         description: Ensure no "fixup!" commits are in the PR
         events:
             -

--- a/tests/fixup.spec.js
+++ b/tests/fixup.spec.js
@@ -1,5 +1,5 @@
 import { client } from 'octonode'
-import { checkFixupCommits } from '../functions/fixup'
+import { handler } from '../functions/fixup'
 
 jest.mock('octonode')
 
@@ -10,7 +10,7 @@ describe('Validating GitHub event', () => {
   test('bad event body', async () => {
     const callback = jest.fn()
 
-    await checkFixupCommits({ body: '{}' }, {}, callback)
+    await handler({ body: '{}' }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -35,7 +35,7 @@ describe('Validating GitHub event', () => {
       },
     }
 
-    await checkFixupCommits({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -60,7 +60,7 @@ describe('Validating GitHub event', () => {
       },
     }
 
-    await checkFixupCommits({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -85,7 +85,7 @@ describe('Validating GitHub event', () => {
       },
     }
 
-    await checkFixupCommits({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -170,7 +170,7 @@ describe('Fixup commits check', () => {
       },
     }
 
-    await checkFixupCommits({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -243,7 +243,7 @@ describe('Fixup commits check', () => {
       },
     }
 
-    await checkFixupCommits({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -309,7 +309,7 @@ describe('Fixup commits check', () => {
       },
     }
 
-    await checkFixupCommits({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {

--- a/tests/label.spec.js
+++ b/tests/label.spec.js
@@ -1,5 +1,5 @@
 import { client } from 'octonode'
-import { checkLabel } from '../functions/label'
+import { handler } from '../functions/label'
 
 jest.mock('octonode')
 
@@ -11,7 +11,7 @@ describe('Validating GitHub event', () => {
   test('bad event body', async () => {
     const callback = jest.fn()
 
-    await checkLabel({ body: '{}' }, {}, callback)
+    await handler({ body: '{}' }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -36,7 +36,7 @@ describe('Validating GitHub event', () => {
       },
     }
 
-    await checkLabel({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -61,7 +61,7 @@ describe('Validating GitHub event', () => {
       },
     }
 
-    await checkLabel({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -86,7 +86,7 @@ describe('Validating GitHub event', () => {
       },
     }
 
-    await checkLabel({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -132,7 +132,7 @@ describe('Validating label', () => {
       },
     }
 
-    await checkLabel({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -182,7 +182,7 @@ describe('Validating label', () => {
       },
     }
 
-    await checkLabel({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -222,7 +222,7 @@ describe('Validating label', () => {
       },
     }
 
-    await checkLabel({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -266,7 +266,7 @@ describe('Validating label', () => {
       },
     }
 
-    await checkLabel({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -310,7 +310,7 @@ describe('Validating label', () => {
       },
     }
 
-    await checkLabel({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -355,7 +355,7 @@ describe('Validating label', () => {
       },
     }
 
-    await checkLabel({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {

--- a/tests/specification.spec.js
+++ b/tests/specification.spec.js
@@ -1,5 +1,5 @@
 import { client } from 'octonode'
-import { checkSpecification } from '../functions/specification'
+import { handler } from '../functions/specification'
 
 jest.mock('octonode')
 
@@ -12,7 +12,7 @@ describe('Validating GitHub event', () => {
   test('bad event body', async () => {
     const callback = jest.fn()
 
-    await checkSpecification({ body: '{}' }, {}, callback)
+    await handler({ body: '{}' }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -37,7 +37,7 @@ describe('Validating GitHub event', () => {
       },
     }
 
-    await checkSpecification({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -62,7 +62,7 @@ describe('Validating GitHub event', () => {
       },
     }
 
-    await checkSpecification({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -87,7 +87,7 @@ describe('Validating GitHub event', () => {
       },
     }
 
-    await checkSpecification({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -128,7 +128,7 @@ describe('Validating specification', () => {
       },
     }
 
-    await checkSpecification({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -167,7 +167,7 @@ describe('Validating specification', () => {
       },
     }
 
-    await checkSpecification({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -206,7 +206,7 @@ describe('Validating specification', () => {
       },
     }
 
-    await checkSpecification({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {


### PR DESCRIPTION
When using a single file to load all handlers, there are all loaded when one lambda is invoked. Which might be a problem.
Instead, remove that file and define all loader using their path in the serverless configuration.