### PR TITLE
Use Graviton2 architecture

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -14,6 +14,7 @@ provider:
     logRetentionInDays: 30
     versionFunctions: false
     deploymentMethod: direct
+    architecture: arm64
     environment:
         NAMESPACE: 20 Minutes
         # SecureString from SSM Parameters


### PR DESCRIPTION
> Lambda functions that use arm64 architecture (AWS Graviton2 processor) can achieve significantly better price and performance than the equivalent function running on x86_64 architecture. 

> Functions that use arm64 architecture offer lower cost per Gb/s compared with the equivalent function running on an x86-based CPU.