### PR TITLE
Handle bad "content type" defined in GitHub webhook

### DIFF
--- a/functions/auto-merge.js
+++ b/functions/auto-merge.js
@@ -3,6 +3,13 @@ import semverDiff from 'semver-diff'
 import { validateWebhook } from './utils/github'
 
 export async function handler(event, context, callback) {
+  if (event.headers?.['content-type'] === 'application/x-www-form-urlencoded') {
+    return callback(null, {
+      statusCode: 500,
+      body: 'Please choose "application/json" as Content type in the webhook definition (you should re-create it)',
+    })
+  }
+
   let response
   const body = JSON.parse(event.body)
 

--- a/functions/fixup.js
+++ b/functions/fixup.js
@@ -2,6 +2,13 @@ import { Octokit } from '@octokit/rest'
 import { updateStatus, validateWebhook } from './utils/github'
 
 export async function handler(event, context, callback) {
+  if (event.headers?.['content-type'] === 'application/x-www-form-urlencoded') {
+    return callback(null, {
+      statusCode: 500,
+      body: 'Please choose "application/json" as Content type in the webhook definition (you should re-create it)',
+    })
+  }
+
   let response
   const githubClient = new Octokit({ auth: process.env.GITHUB_TOKEN })
   const payload = {

--- a/functions/label.js
+++ b/functions/label.js
@@ -2,6 +2,13 @@ import { Octokit } from '@octokit/rest'
 import { updateStatus, validateWebhook } from './utils/github'
 
 export async function handler(event, context, callback) {
+  if (event.headers?.['content-type'] === 'application/x-www-form-urlencoded') {
+    return callback(null, {
+      statusCode: 500,
+      body: 'Please choose "application/json" as Content type in the webhook definition (you should re-create it)',
+    })
+  }
+
   let response
   const githubClient = new Octokit({ auth: process.env.GITHUB_TOKEN })
   const blockLabels = process.env.BLOCK_LABELS

--- a/functions/specification.js
+++ b/functions/specification.js
@@ -2,6 +2,13 @@ import { Octokit } from '@octokit/rest'
 import { updateStatus, validateWebhook } from './utils/github'
 
 export async function handler(event, context, callback) {
+  if (event.headers?.['content-type'] === 'application/x-www-form-urlencoded') {
+    return callback(null, {
+      statusCode: 500,
+      body: 'Please choose "application/json" as Content type in the webhook definition (you should re-create it)',
+    })
+  }
+
   let response
   const githubClient = new Octokit({ auth: process.env.GITHUB_TOKEN })
 

--- a/tests/auto-merge.spec.js
+++ b/tests/auto-merge.spec.js
@@ -5,6 +5,25 @@ import { handler } from '../functions/auto-merge'
 process.env.NAMESPACE = '20 Minutes'
 
 describe('Validating GitHub event', () => {
+  test('bad content type', async () => {
+    const callback = jest.fn()
+
+    await handler(
+      {
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: 'payload%3D%7B%22zen%22%3A%22Non-blocking%2Bis%2Bbetter%2Bthan%2Bblocking.%22%7D',
+      },
+      {},
+      callback
+    )
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith(null, {
+      body: 'Please choose "application/json" as Content type in the webhook definition (you should re-create it)',
+      statusCode: 500,
+    })
+  })
+
   test('bad event body', async () => {
     const callback = jest.fn()
 

--- a/tests/fixup.spec.js
+++ b/tests/fixup.spec.js
@@ -5,6 +5,25 @@ import { handler } from '../functions/fixup'
 process.env.NAMESPACE = '20 Minutes'
 
 describe('Validating GitHub event', () => {
+  test('bad content type', async () => {
+    const callback = jest.fn()
+
+    await handler(
+      {
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: 'payload%3D%7B%22zen%22%3A%22Non-blocking%2Bis%2Bbetter%2Bthan%2Bblocking.%22%7D',
+      },
+      {},
+      callback
+    )
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith(null, {
+      body: 'Please choose "application/json" as Content type in the webhook definition (you should re-create it)',
+      statusCode: 500,
+    })
+  })
+
   test('bad event body', async () => {
     const callback = jest.fn()
 

--- a/tests/label.spec.js
+++ b/tests/label.spec.js
@@ -6,6 +6,25 @@ process.env.NAMESPACE = '20 Minutes'
 process.env.BLOCK_LABELS = 'wip , work in progress'
 
 describe('Validating GitHub event', () => {
+  test('bad content type', async () => {
+    const callback = jest.fn()
+
+    await handler(
+      {
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: 'payload%3D%7B%22zen%22%3A%22Non-blocking%2Bis%2Bbetter%2Bthan%2Bblocking.%22%7D',
+      },
+      {},
+      callback
+    )
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith(null, {
+      body: 'Please choose "application/json" as Content type in the webhook definition (you should re-create it)',
+      statusCode: 500,
+    })
+  })
+
   test('bad event body', async () => {
     const callback = jest.fn()
 

--- a/tests/specification.spec.js
+++ b/tests/specification.spec.js
@@ -7,6 +7,25 @@ process.env.CHECK_BODY_LENGTH = 8
 process.env.CHECK_TITLE_LENGTH = 8
 
 describe('Validating GitHub event', () => {
+  test('bad content type', async () => {
+    const callback = jest.fn()
+
+    await handler(
+      {
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: 'payload%3D%7B%22zen%22%3A%22Non-blocking%2Bis%2Bbetter%2Bthan%2Bblocking.%22%7D',
+      },
+      {},
+      callback
+    )
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith(null, {
+      body: 'Please choose "application/json" as Content type in the webhook definition (you should re-create it)',
+      statusCode: 500,
+    })
+  })
+
   test('bad event body', async () => {
     const callback = jest.fn()
 


### PR DESCRIPTION
Just to avoid having an "internal server error" when we define the webhook with the wrong content type.