### PR TITLE
Increase timeout for fixup

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -65,6 +65,7 @@ functions:
     fixup:
         handler: functions/fixup.handler
         description: Ensure no "fixup!" commits are in the PR
+        timeout: 10
         events:
             -
                 http:


### PR DESCRIPTION
Looks like it usually took abour 6s to handle the request, jump to 10s to avoid timeout.