### PR TITLE
Handle alpha version with a `-` in the version

### DIFF
--- a/functions/classes/AutomergeHandler.js
+++ b/functions/classes/AutomergeHandler.js
@@ -51,7 +51,7 @@ export class AutomergeHandler extends Handler {
     }
 
     let updateType
-    const titleMatch = body.pull_request.title.match(/from ([\w.]+) to ([\w.]+)/i)
+    const titleMatch = body.pull_request.title.match(/from ([\w.-]+) to ([\w.-]+)/i)
 
     // try for one deps to be updated
     // otherwise try for grouped deps, look for new version in the body instead

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "main": "handler.js",
   "scripts": {
     "test": "jest --silent",
+    "test:watch": "jest --watch",
     "lint": "eslint functions/ tests/"
   },
   "author": "20 Minutes <web-tech@20minutes.fr>",


### PR DESCRIPTION
When the version is named `package-alpha.54` the regex matched nothing.